### PR TITLE
Fix range of ranges in loader

### DIFF
--- a/iiif_prezi/factory.py
+++ b/iiif_prezi/factory.py
@@ -1412,11 +1412,14 @@ class Range(BaseMetadataObject):
 
 	def add_range(self, rng):
 		"""Add Range to this Range."""
-		self.ranges.append(rng.id)		
+		if type(rng) in STR_TYPES and is_http_uri(rng):
+			self.ranges.append(rng)
+		else:
+			self.ranges.append(rng.id)		
 
 	def set_start_canvas(self, cvs):
 		"""Set the start Canvas."""
-		if type(cvs) in [unicode, str]:
+		if type(cvs) in STR_TYPES:
 			cvsid = cvs
 		elif isinstance(cvs, Canvas):
 			cvsid = cvs.id

--- a/tests/range_range_fixture.json
+++ b/tests/range_range_fixture.json
@@ -1,0 +1,11590 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "http://data.getty.edu/iiif/2007d1_d2941/manifest.json",
+  "@type": "sc:Manifest",
+  "label": "Sculptures: Italian",
+  "metadata": [
+    {
+      "label": "Author/Creator",
+      "value": "Duveen Brothers"
+    },
+    {
+      "label": "Creation Date",
+      "value": "undated"
+    },
+    {
+      "label": "Form/Genre",
+      "value": [
+        "Black-and-white photographs",
+        "Photographs, Original",
+        "Mixed material"
+      ]
+    },
+    {
+      "label": "Physical Desc.",
+      "value": "circa 225 photographs"
+    },
+    {
+      "label": "Subject",
+      "value": [
+        "Duveen Brothers",
+        "Sculpture--Collectors and collecting"
+      ]
+    },
+    {
+      "label": "ID/Acc. No.",
+      "value": [
+        "2007.D.1 (bx.461-463)",
+        "http://hdl.handle.net/10020/2007d1_d2941"
+      ]
+    },
+    {
+      "label": "Is Part Of",
+      "value": [
+        "Duveen Brothers stock documentation from the dealer\u2019s library, 1829-1965. Series VII. Photographs, 1898-circa 1960. Series VII.C. Sculptures, 1898-circa 1960 (http://hdl.handle.net/10020/cat717039)",
+        "GRI Special Collections"
+      ]
+    },
+    {
+      "label": "Use Restrictions",
+      "value": "Be aware that third parties may claim privacy or publicity rights in these images, or rights to artworks depicted that are not in the public domain. Users assume full responsibility for their use of these images. By downloading these images you agree that it is your responsibility to identify any potential claimants and obtain any necessary permissions for your use, and you agree to indemnify, defend, and hold the repository libraries harmless from all costs, charges, fees, or expenses, losses, damages, liabilities, or judgments arising from or relating to any claim, cause, or allegation asserted by a third party against the repository libraries based entirely or in part on your use of the images."
+    }
+  ],
+  "description": "The Duveen Brothers was a firm of influential art dealers from the late nineteenth to the mid-twentieth century based in London, Paris, and New York. With Joseph Duveen (1869-1939) at the helm and the assistance of art experts, most notably Bernard Berenson (1865-1959), Duveen Brothers played a prominent role in the transfer of old master paintings, antique furnishings, and objets d'art from Europe to the United States. The photographs in Series VII.C. Sculptures are a record of the sculptures handled by the firm of Duveen Brothers. In the photographic files are also reference photographs unrelated to the firm's stock.",
+  "attribution": "The Getty Research Institute, Los Angeles.",
+  "license": "http://hdl.handle.net/10020/repro_perm",
+  "viewingHint": "individuals",
+  "sequences": [
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/sequence/regular.json",
+      "@type": "sc:Sequence",
+      "label": "Regular Order",
+      "canvases": [
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067697.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3744,
+          "width": 2888,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067697.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3744,
+                "width": 2888,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067697.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067697.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067706.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3734,
+          "width": 2873,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067706.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3734,
+                "width": 2873,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067706.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067706.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067718.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 4121,
+          "width": 3242,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067718.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4121,
+                "width": 3242,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067718.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067718.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067731.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 4121,
+          "width": 3242,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067731.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4121,
+                "width": 3242,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067731.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067731.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067741.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 1781,
+          "width": 1742,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067741.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1781,
+                "width": 1742,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067741.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067741.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067749.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 1781,
+          "width": 1742,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067749.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1781,
+                "width": 1742,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067749.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067749.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067754.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 3968,
+          "width": 3214,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067754.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3968,
+                "width": 3214,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067754.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067754.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067761.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 3968,
+          "width": 3203,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067761.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3968,
+                "width": 3203,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067761.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067761.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067770.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 4201,
+          "width": 3132,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067770.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4201,
+                "width": 3132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067770.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067770.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067777.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 4191,
+          "width": 3132,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067777.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4191,
+                "width": 3132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067777.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067777.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067785.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 3377,
+          "width": 2645,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067785.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3377,
+                "width": 2645,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067785.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067785.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067793.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 2530,
+          "width": 3086,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067793.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2530,
+                "width": 3086,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067793.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067793.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067802.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 2490,
+          "width": 3077,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067802.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2490,
+                "width": 3077,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067802.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067802.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067807.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 4221,
+          "width": 3326,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067807.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4221,
+                "width": 3326,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067807.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067807.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067816.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4221,
+          "width": 3341,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067816.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4221,
+                "width": 3341,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067816.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067816.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067826.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3054,
+          "width": 2437,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067826.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3054,
+                "width": 2437,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067826.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067826.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067835.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3054,
+          "width": 2437,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067835.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3054,
+                "width": 2437,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067835.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067835.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067844.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 2446,
+          "width": 2954,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067844.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2446,
+                "width": 2954,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067844.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067844.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067849.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 2387,
+          "width": 3049,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067849.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2387,
+                "width": 3049,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067849.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067849.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067859.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 2460,
+          "width": 2991,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067859.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2460,
+                "width": 2991,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067859.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067859.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067868.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 2373,
+          "width": 3037,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067868.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2373,
+                "width": 3037,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067868.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067868.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067875.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 4116,
+          "width": 3265,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067875.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4116,
+                "width": 3265,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067875.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067875.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067882.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 4106,
+          "width": 3265,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067882.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4106,
+                "width": 3265,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067882.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067882.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067889.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 3961,
+          "width": 3358,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067889.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3961,
+                "width": 3358,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067889.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067889.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067900.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 3955,
+          "width": 3348,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067900.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3955,
+                "width": 3348,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067900.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067900.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067909.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 3924,
+          "width": 3343,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067909.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3924,
+                "width": 3343,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067909.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067909.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067921.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 3914,
+          "width": 3343,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067921.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3914,
+                "width": 3343,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067921.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067921.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067931.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 4069,
+          "width": 3296,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067931.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4069,
+                "width": 3296,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067931.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067931.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067948.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 4064,
+          "width": 3296,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067948.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4064,
+                "width": 3296,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067948.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067948.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067954.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 3701,
+          "width": 3192,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067954.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3701,
+                "width": 3192,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067954.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067954.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067960.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 4147,
+          "width": 3295,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067960.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4147,
+                "width": 3295,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067960.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067960.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067972.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 4142,
+          "width": 3295,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067972.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4142,
+                "width": 3295,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067972.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067972.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067980.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3822,
+          "width": 3127,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067980.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3822,
+                "width": 3127,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067980.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067980.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067989.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3811,
+          "width": 3132,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067989.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3811,
+                "width": 3132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067989.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067989.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067999.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 4076,
+          "width": 3215,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067999.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4076,
+                "width": 3215,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2067999.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067999.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068007.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 4065,
+          "width": 3210,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068007.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4065,
+                "width": 3210,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068007.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068007.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068015.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 4184,
+          "width": 3325,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068015.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4184,
+                "width": 3325,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068015.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068015.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068024.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 4174,
+          "width": 3320,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068024.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4174,
+                "width": 3320,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068024.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068024.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068032.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 3053,
+          "width": 2487,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068032.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3053,
+                "width": 2487,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068032.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068032.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068040.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 3063,
+          "width": 2492,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068040.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3063,
+                "width": 2492,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068040.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068040.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068048.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 3063,
+          "width": 2508,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068048.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3063,
+                "width": 2508,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068048.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068048.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068056.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 3063,
+          "width": 2508,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068056.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3063,
+                "width": 2508,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068056.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068056.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068061.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 2824,
+          "width": 2305,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068061.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2824,
+                "width": 2305,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068061.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068061.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068068.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 2819,
+          "width": 2300,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068068.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2819,
+                "width": 2300,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068068.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068068.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068076.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 2902,
+          "width": 2119,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068076.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2902,
+                "width": 2119,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068076.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068076.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068082.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 2907,
+          "width": 2118,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068082.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2907,
+                "width": 2118,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068082.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068082.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068086.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4159,
+          "width": 3113,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068086.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4159,
+                "width": 3113,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068086.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068086.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068093.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 4164,
+          "width": 3118,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068093.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4164,
+                "width": 3118,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068093.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068093.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068098.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 3614,
+          "width": 3108,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068098.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3614,
+                "width": 3108,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068098.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068098.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068106.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 3604,
+          "width": 3118,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068106.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3604,
+                "width": 3118,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068106.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068106.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068111.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 4239,
+          "width": 2384,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068111.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4239,
+                "width": 2384,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068111.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068111.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068117.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 4239,
+          "width": 2384,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068117.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4239,
+                "width": 2384,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068117.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068117.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068126.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 2891,
+          "width": 2379,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068126.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2891,
+                "width": 2379,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068126.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068126.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068133.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 2881,
+          "width": 2389,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068133.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2881,
+                "width": 2389,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068133.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068133.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068138.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 2886,
+          "width": 2467,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068138.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2886,
+                "width": 2467,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068138.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068138.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068147.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 2886,
+          "width": 2467,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068147.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2886,
+                "width": 2467,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068147.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068147.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068153.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 2715,
+          "width": 2343,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068153.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2715,
+                "width": 2343,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068153.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068153.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068158.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 2715,
+          "width": 2348,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068158.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2715,
+                "width": 2348,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068158.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068158.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068166.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 2814,
+          "width": 2322,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068166.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2814,
+                "width": 2322,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068166.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068166.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068173.json",
+          "@type": "sc:Canvas",
+          "label": "Image 028",
+          "height": 2798,
+          "width": 2306,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068173.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2798,
+                "width": 2306,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068173.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068173.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068179.json",
+          "@type": "sc:Canvas",
+          "label": "Image 029",
+          "height": 2674,
+          "width": 2737,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068179.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2674,
+                "width": 2737,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068179.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068179.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068186.json",
+          "@type": "sc:Canvas",
+          "label": "Image 030",
+          "height": 2669,
+          "width": 2721,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068186.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2669,
+                "width": 2721,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068186.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068186.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068192.json",
+          "@type": "sc:Canvas",
+          "label": "Image 031",
+          "height": 3773,
+          "width": 3230,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068192.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3773,
+                "width": 3230,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068192.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068192.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068198.json",
+          "@type": "sc:Canvas",
+          "label": "Image 032",
+          "height": 4151,
+          "width": 3209,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068198.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4151,
+                "width": 3209,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068198.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068198.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068206.json",
+          "@type": "sc:Canvas",
+          "label": "Image 033",
+          "height": 4151,
+          "width": 3209,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068206.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4151,
+                "width": 3209,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068206.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068206.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068213.json",
+          "@type": "sc:Canvas",
+          "label": "Image 034",
+          "height": 3820,
+          "width": 3220,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068213.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3820,
+                "width": 3220,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068213.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068213.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068220.json",
+          "@type": "sc:Canvas",
+          "label": "Image 035",
+          "height": 3825,
+          "width": 3204,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068220.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3825,
+                "width": 3204,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068220.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068220.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068230.json",
+          "@type": "sc:Canvas",
+          "label": "Image 036",
+          "height": 3918,
+          "width": 3080,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068230.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3918,
+                "width": 3080,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068230.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068230.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068241.json",
+          "@type": "sc:Canvas",
+          "label": "Image 037",
+          "height": 3897,
+          "width": 3080,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068241.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3897,
+                "width": 3080,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068241.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068241.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068250.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 4123,
+          "width": 3272,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068250.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4123,
+                "width": 3272,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068250.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068250.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068259.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 4112,
+          "width": 3262,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068259.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4112,
+                "width": 3262,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068259.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068259.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068268.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 3977,
+          "width": 3200,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068268.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3977,
+                "width": 3200,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068268.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068268.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068279.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 3962,
+          "width": 3184,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068279.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3962,
+                "width": 3184,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068279.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068279.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068290.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 4029,
+          "width": 3272,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068290.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4029,
+                "width": 3272,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068290.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068290.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068299.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 4070,
+          "width": 3236,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068299.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4070,
+                "width": 3236,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068299.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068299.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068308.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 4070,
+          "width": 3246,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068308.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4070,
+                "width": 3246,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068308.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068308.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068318.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 3920,
+          "width": 3210,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068318.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3920,
+                "width": 3210,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068318.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068318.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068327.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 3904,
+          "width": 3194,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068327.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3904,
+                "width": 3194,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068327.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068327.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068334.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 4075,
+          "width": 2882,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068334.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4075,
+                "width": 2882,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068334.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068334.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068337.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 4075,
+          "width": 2887,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068337.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4075,
+                "width": 2887,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068337.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068337.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068341.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 4095,
+          "width": 3126,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068341.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4095,
+                "width": 3126,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068341.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068341.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068345.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 4095,
+          "width": 3126,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068345.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4095,
+                "width": 3126,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068345.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068345.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068350.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 3741,
+          "width": 2584,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068350.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3741,
+                "width": 2584,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068350.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068350.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068354.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 3735,
+          "width": 2583,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068354.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3735,
+                "width": 2583,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068354.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068354.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068358.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 4161,
+          "width": 3254,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068358.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4161,
+                "width": 3254,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068358.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068358.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068363.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 4176,
+          "width": 3248,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068363.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4176,
+                "width": 3248,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068363.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068363.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068367.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 4166,
+          "width": 3077,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068367.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4166,
+                "width": 3077,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068367.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068367.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068371.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 4166,
+          "width": 3077,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068371.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4166,
+                "width": 3077,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068371.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068371.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068374.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 4140,
+          "width": 3285,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068374.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4140,
+                "width": 3285,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068374.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068374.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068378.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 4140,
+          "width": 3300,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068378.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4140,
+                "width": 3300,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068378.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068378.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068382.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 3025,
+          "width": 2368,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068382.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3025,
+                "width": 2368,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068382.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068382.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068386.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 3025,
+          "width": 2358,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068386.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3025,
+                "width": 2358,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068386.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068386.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068390.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 3231,
+          "width": 2587,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068390.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3231,
+                "width": 2587,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068390.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068390.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068395.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 3252,
+          "width": 2592,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068395.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3252,
+                "width": 2592,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068395.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068395.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068399.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 3024,
+          "width": 2416,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068399.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3024,
+                "width": 2416,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068399.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068399.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068405.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 3029,
+          "width": 2406,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068405.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3029,
+                "width": 2406,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068405.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068405.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068409.json",
+          "@type": "sc:Canvas",
+          "label": "Image 028",
+          "height": 2946,
+          "width": 2421,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068409.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2946,
+                "width": 2421,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068409.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068409.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068413.json",
+          "@type": "sc:Canvas",
+          "label": "Image 029",
+          "height": 2936,
+          "width": 2411,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068413.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2936,
+                "width": 2411,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068413.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068413.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068417.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3002,
+          "width": 2411,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068417.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3002,
+                "width": 2411,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068417.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068417.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068424.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 2997,
+          "width": 2406,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068424.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2997,
+                "width": 2406,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068424.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068424.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068432.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 2965,
+          "width": 2354,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068432.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2965,
+                "width": 2354,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068432.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068432.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068440.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 2966,
+          "width": 2349,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068440.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2966,
+                "width": 2349,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068440.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068440.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068448.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 3038,
+          "width": 2427,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068448.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3038,
+                "width": 2427,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068448.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068448.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068456.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 3521,
+          "width": 3023,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068456.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3521,
+                "width": 3023,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068456.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068456.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068462.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 3858,
+          "width": 3287,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068462.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3858,
+                "width": 3287,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068462.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068462.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068475.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 3858,
+          "width": 3282,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068475.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3858,
+                "width": 3282,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068475.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068475.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068482.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 4107,
+          "width": 3163,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068482.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4107,
+                "width": 3163,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068482.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068482.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068492.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 4107,
+          "width": 3163,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068492.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4107,
+                "width": 3163,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068492.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068492.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068498.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 4164,
+          "width": 3215,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068498.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4164,
+                "width": 3215,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068498.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068498.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068507.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 4159,
+          "width": 3205,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068507.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4159,
+                "width": 3205,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068507.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068507.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068515.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 4122,
+          "width": 3059,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068515.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4122,
+                "width": 3059,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068515.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068515.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068523.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 4122,
+          "width": 3059,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068523.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4122,
+                "width": 3059,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068523.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068523.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068531.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4148,
+          "width": 3189,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068531.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4148,
+                "width": 3189,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068531.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068531.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068539.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 4153,
+          "width": 3189,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068539.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4153,
+                "width": 3189,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068539.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068539.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068545.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 3365,
+          "width": 2633,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068545.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3365,
+                "width": 2633,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068545.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068545.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068554.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 3070,
+          "width": 2509,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068554.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3070,
+                "width": 2509,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068554.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068554.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068561.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 3070,
+          "width": 2509,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068561.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3070,
+                "width": 2509,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068561.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068561.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068569.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 4044,
+          "width": 3050,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068569.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4044,
+                "width": 3050,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068569.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068569.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068577.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 4033,
+          "width": 3045,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068577.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4033,
+                "width": 3045,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068577.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068577.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068588.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 3830,
+          "width": 2952,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068588.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3830,
+                "width": 2952,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068588.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068588.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068596.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 3841,
+          "width": 2952,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068596.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3841,
+                "width": 2952,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068596.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068596.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068602.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 4153,
+          "width": 3242,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068602.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4153,
+                "width": 3242,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068602.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068602.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068611.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 4147,
+          "width": 3241,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068611.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4147,
+                "width": 3241,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068611.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068611.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068621.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 4641,
+          "width": 3108,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068621.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4641,
+                "width": 3108,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068621.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068621.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068630.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 4636,
+          "width": 3111,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068630.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4636,
+                "width": 3111,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068630.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068630.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068637.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 2487,
+          "width": 3069,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068637.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2487,
+                "width": 3069,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068637.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068637.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068649.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 2487,
+          "width": 3064,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068649.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2487,
+                "width": 3064,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068649.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068649.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068656.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 4247,
+          "width": 3254,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068656.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4247,
+                "width": 3254,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068656.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068656.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068666.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 4242,
+          "width": 3238,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068666.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4242,
+                "width": 3238,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068666.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068666.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068674.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 4118,
+          "width": 2958,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068674.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4118,
+                "width": 2958,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068674.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068674.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068684.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 4128,
+          "width": 2958,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068684.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4128,
+                "width": 2958,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068684.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068684.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068693.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 4190,
+          "width": 3207,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068693.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4190,
+                "width": 3207,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068693.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068693.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068706.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 4195,
+          "width": 3223,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068706.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4195,
+                "width": 3223,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068706.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068706.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068713.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 2894,
+          "width": 2417,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068713.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2894,
+                "width": 2417,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068713.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068713.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068727.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 2909,
+          "width": 2417,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068727.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2909,
+                "width": 2417,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068727.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068727.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068737.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 2956,
+          "width": 2401,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068737.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2956,
+                "width": 2401,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068737.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068737.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068749.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 2966,
+          "width": 2391,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068749.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2966,
+                "width": 2391,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068749.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068749.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068755.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 3029,
+          "width": 2111,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068755.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3029,
+                "width": 2111,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068755.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068755.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068763.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 3029,
+          "width": 2106,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068763.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3029,
+                "width": 2106,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068763.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068763.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068774.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4070,
+          "width": 2730,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068774.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4070,
+                "width": 2730,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068774.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068774.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068784.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 4075,
+          "width": 2735,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068784.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4075,
+                "width": 2735,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068784.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068784.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068794.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 4111,
+          "width": 3000,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068794.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4111,
+                "width": 3000,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068794.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068794.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068801.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 4121,
+          "width": 3000,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068801.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4121,
+                "width": 3000,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068801.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068801.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068812.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 4132,
+          "width": 3217,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068812.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4132,
+                "width": 3217,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068812.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068812.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068817.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3998,
+          "width": 3205,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068817.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3998,
+                "width": 3205,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068817.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068817.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068823.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 4107,
+          "width": 3194,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068823.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4107,
+                "width": 3194,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068823.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068823.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068835.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 4159,
+          "width": 3376,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068835.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4159,
+                "width": 3376,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068835.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068835.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068846.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 4148,
+          "width": 3376,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068846.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4148,
+                "width": 3376,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068846.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068846.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068855.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 4179,
+          "width": 3293,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068855.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4179,
+                "width": 3293,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068855.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068855.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068865.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 4174,
+          "width": 3288,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068865.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4174,
+                "width": 3288,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068865.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068865.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068874.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 4169,
+          "width": 3282,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068874.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4169,
+                "width": 3282,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068874.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068874.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068884.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 4158,
+          "width": 3283,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068884.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4158,
+                "width": 3283,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068884.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068884.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068892.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 4190,
+          "width": 3345,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068892.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4190,
+                "width": 3345,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068892.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068892.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068901.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 4190,
+          "width": 3355,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068901.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4190,
+                "width": 3355,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068901.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068901.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068909.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 3174,
+          "width": 4111,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068909.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3174,
+                "width": 4111,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068909.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068909.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068917.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 4090,
+          "width": 3314,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068917.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4090,
+                "width": 3314,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068917.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068917.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068921.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 4100,
+          "width": 3314,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068921.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4100,
+                "width": 3314,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068921.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068921.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068931.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 4043,
+          "width": 3257,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068931.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4043,
+                "width": 3257,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068931.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068931.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068941.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4059,
+          "width": 3262,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068941.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4059,
+                "width": 3262,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068941.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068941.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068959.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 3079,
+          "width": 2240,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068959.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3079,
+                "width": 2240,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068959.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068959.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068967.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 3085,
+          "width": 2246,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068967.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3085,
+                "width": 2246,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068967.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068967.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068975.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 2939,
+          "width": 2328,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068975.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2939,
+                "width": 2328,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068975.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068975.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068983.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 2933,
+          "width": 2333,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068983.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2933,
+                "width": 2333,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068983.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068983.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068991.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 3058,
+          "width": 2284,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068991.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3058,
+                "width": 2284,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068991.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068991.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068998.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 3073,
+          "width": 2284,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068998.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3073,
+                "width": 2284,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2068998.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068998.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069006.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 3073,
+          "width": 2522,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069006.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3073,
+                "width": 2522,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069006.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069006.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069014.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 3084,
+          "width": 2517,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069014.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3084,
+                "width": 2517,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069014.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069014.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069023.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3080,
+          "width": 2474,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069023.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3080,
+                "width": 2474,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069023.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069023.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069033.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3059,
+          "width": 2484,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069033.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3059,
+                "width": 2484,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069033.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069033.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069040.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 3054,
+          "width": 2385,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069040.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3054,
+                "width": 2385,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069040.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069040.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069058.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 3054,
+          "width": 2380,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069058.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3054,
+                "width": 2380,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069058.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069058.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069068.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 3059,
+          "width": 2463,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069068.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3059,
+                "width": 2463,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069068.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069068.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069079.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 3054,
+          "width": 2458,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069079.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3054,
+                "width": 2458,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069079.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069079.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069089.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 2950,
+          "width": 2422,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069089.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2950,
+                "width": 2422,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069089.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069089.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069096.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 3064,
+          "width": 2478,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069096.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3064,
+                "width": 2478,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069096.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069096.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069108.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 3054,
+          "width": 2478,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069108.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3054,
+                "width": 2478,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069108.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069108.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069116.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 3184,
+          "width": 1784,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069116.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3184,
+                "width": 1784,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069116.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069116.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069136.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 2929,
+          "width": 2318,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069136.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2929,
+                "width": 2318,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069136.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069136.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069144.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 2934,
+          "width": 2328,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069144.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2934,
+                "width": 2328,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069144.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069144.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069153.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 3028,
+          "width": 2499,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069153.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3028,
+                "width": 2499,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069153.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069153.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069162.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 3462,
+          "width": 3023,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069162.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3462,
+                "width": 3023,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069162.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069162.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069169.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 3887,
+          "width": 3028,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069169.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3887,
+                "width": 3028,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069169.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069169.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069177.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 2793,
+          "width": 2038,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069177.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2793,
+                "width": 2038,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069177.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069177.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069184.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 4106,
+          "width": 3146,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069184.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4106,
+                "width": 3146,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069184.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069184.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069194.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 4101,
+          "width": 3131,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069194.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4101,
+                "width": 3131,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069194.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069194.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069204.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 4173,
+          "width": 3281,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069204.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4173,
+                "width": 3281,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069204.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069204.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069210.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 4168,
+          "width": 3266,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069210.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4168,
+                "width": 3266,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069210.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069210.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069219.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 4096,
+          "width": 3209,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069219.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4096,
+                "width": 3209,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069219.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069219.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069236.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 4090,
+          "width": 3204,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069236.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4090,
+                "width": 3204,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069236.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069236.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069246.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 2964,
+          "width": 2464,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069246.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2964,
+                "width": 2464,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069246.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069246.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069256.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 2959,
+          "width": 2448,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069256.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2959,
+                "width": 2448,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069256.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069256.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069264.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 2432,
+          "width": 3042,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069264.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2432,
+                "width": 3042,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069264.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069264.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069275.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 2419,
+          "width": 3037,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069275.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2419,
+                "width": 3037,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069275.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069275.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069285.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 3839,
+          "width": 2928,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069285.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3839,
+                "width": 2928,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069285.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069285.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069294.json",
+          "@type": "sc:Canvas",
+          "label": "Image 028",
+          "height": 4196,
+          "width": 2739,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069294.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4196,
+                "width": 2739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069294.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069294.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069302.json",
+          "@type": "sc:Canvas",
+          "label": "Image 029",
+          "height": 4201,
+          "width": 2739,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069302.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4201,
+                "width": 2739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069302.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069302.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069313.json",
+          "@type": "sc:Canvas",
+          "label": "Image 030",
+          "height": 4242,
+          "width": 2801,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069313.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4242,
+                "width": 2801,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069313.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069313.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069333.json",
+          "@type": "sc:Canvas",
+          "label": "Image 031",
+          "height": 4248,
+          "width": 2817,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069333.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4248,
+                "width": 2817,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069333.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069333.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069345.json",
+          "@type": "sc:Canvas",
+          "label": "Image 032",
+          "height": 4175,
+          "width": 3138,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069345.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4175,
+                "width": 3138,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069345.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069345.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069349.json",
+          "@type": "sc:Canvas",
+          "label": "Image 033",
+          "height": 4175,
+          "width": 3138,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069349.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4175,
+                "width": 3138,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069349.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069349.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069371.json",
+          "@type": "sc:Canvas",
+          "label": "Image 034",
+          "height": 4174,
+          "width": 3143,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069371.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4174,
+                "width": 3143,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069371.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069371.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069380.json",
+          "@type": "sc:Canvas",
+          "label": "Image 035",
+          "height": 4222,
+          "width": 3252,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069380.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4222,
+                "width": 3252,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069380.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069380.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069389.json",
+          "@type": "sc:Canvas",
+          "label": "Image 036",
+          "height": 4227,
+          "width": 3226,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069389.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4227,
+                "width": 3226,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069389.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069389.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069398.json",
+          "@type": "sc:Canvas",
+          "label": "Image 037",
+          "height": 3802,
+          "width": 3034,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069398.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3802,
+                "width": 3034,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069398.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069398.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069407.json",
+          "@type": "sc:Canvas",
+          "label": "Image 038",
+          "height": 3791,
+          "width": 3019,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069407.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3791,
+                "width": 3019,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069407.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069407.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069417.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3106,
+          "width": 2453,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069417.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3106,
+                "width": 2453,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069417.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069417.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069424.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3423,
+          "width": 2649,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069424.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3423,
+                "width": 2649,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069424.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069424.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069432.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 3434,
+          "width": 2644,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069432.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3434,
+                "width": 2644,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069432.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069432.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069442.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 2878,
+          "width": 2375,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069442.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2878,
+                "width": 2375,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069442.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069442.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069453.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 2894,
+          "width": 2364,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069453.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2894,
+                "width": 2364,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069453.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069453.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069459.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 3096,
+          "width": 2427,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069459.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3096,
+                "width": 2427,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069459.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069459.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069469.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 3106,
+          "width": 2417,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069469.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3106,
+                "width": 2417,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069469.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069469.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069479.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 3117,
+          "width": 2427,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069479.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3117,
+                "width": 2427,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069479.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069479.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069487.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 2972,
+          "width": 2411,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069487.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2972,
+                "width": 2411,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069487.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069487.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069497.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 2961,
+          "width": 2406,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069497.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2961,
+                "width": 2406,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069497.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069497.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069504.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 3836,
+          "width": 2948,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069504.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3836,
+                "width": 2948,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069504.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069504.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069511.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 2752,
+          "width": 2797,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069511.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2752,
+                "width": 2797,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069511.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069511.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069519.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 3350,
+          "width": 2622,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069519.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3350,
+                "width": 2622,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069519.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069519.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069535.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 4119,
+          "width": 3316,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069535.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4119,
+                "width": 3316,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069535.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069535.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069542.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4139,
+          "width": 3316,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069542.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4139,
+                "width": 3316,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069542.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069542.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069555.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 4144,
+          "width": 3285,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069555.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4144,
+                "width": 3285,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069555.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069555.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069564.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 4144,
+          "width": 3165,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069564.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4144,
+                "width": 3165,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069564.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069564.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069570.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 4160,
+          "width": 3253,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069570.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4160,
+                "width": 3253,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069570.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069570.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069578.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 4165,
+          "width": 3269,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069578.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4165,
+                "width": 3269,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069578.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069578.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069586.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 4113,
+          "width": 3269,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069586.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4113,
+                "width": 3269,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069586.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069586.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069595.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 4108,
+          "width": 3264,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069595.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4108,
+                "width": 3264,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069595.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069595.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069607.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 4160,
+          "width": 3233,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069607.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4160,
+                "width": 3233,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069607.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069607.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069619.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 4160,
+          "width": 3228,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069619.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4160,
+                "width": 3228,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069619.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069619.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069628.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 3444,
+          "width": 2398,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069628.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3444,
+                "width": 2398,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069628.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069628.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069637.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 3444,
+          "width": 2393,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069637.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3444,
+                "width": 2393,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069637.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069637.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069646.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 2138,
+          "width": 2936,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069646.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2138,
+                "width": 2936,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069646.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069646.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069654.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 2138,
+          "width": 2940,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069654.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2138,
+                "width": 2940,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069654.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069654.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069662.json",
+          "@type": "sc:Canvas",
+          "label": "Image 028",
+          "height": 3102,
+          "width": 4163,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069662.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3102,
+                "width": 4163,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069662.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069662.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069678.json",
+          "@type": "sc:Canvas",
+          "label": "Image 029",
+          "height": 2905,
+          "width": 2419,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069678.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2905,
+                "width": 2419,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069678.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069678.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069686.json",
+          "@type": "sc:Canvas",
+          "label": "Image 030",
+          "height": 4096,
+          "width": 2809,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069686.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4096,
+                "width": 2809,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069686.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069686.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069694.json",
+          "@type": "sc:Canvas",
+          "label": "Image 031",
+          "height": 4106,
+          "width": 2809,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069694.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4106,
+                "width": 2809,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069694.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069694.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069700.json",
+          "@type": "sc:Canvas",
+          "label": "Image 032",
+          "height": 4111,
+          "width": 3078,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069700.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4111,
+                "width": 3078,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069700.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069700.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069709.json",
+          "@type": "sc:Canvas",
+          "label": "Image 033",
+          "height": 4111,
+          "width": 3089,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069709.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4111,
+                "width": 3089,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069709.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069709.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069717.json",
+          "@type": "sc:Canvas",
+          "label": "Image 034",
+          "height": 3153,
+          "width": 2449,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069717.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3153,
+                "width": 2449,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069717.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069717.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069727.json",
+          "@type": "sc:Canvas",
+          "label": "Image 035",
+          "height": 4216,
+          "width": 3246,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069727.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4216,
+                "width": 3246,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069727.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069727.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069737.json",
+          "@type": "sc:Canvas",
+          "label": "Image 036",
+          "height": 4205,
+          "width": 3246,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069737.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4205,
+                "width": 3246,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069737.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069737.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069746.json",
+          "@type": "sc:Canvas",
+          "label": "Image 037",
+          "height": 4205,
+          "width": 2727,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069746.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4205,
+                "width": 2727,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069746.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069746.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069761.json",
+          "@type": "sc:Canvas",
+          "label": "Image 038",
+          "height": 4185,
+          "width": 2717,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069761.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4185,
+                "width": 2717,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069761.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069761.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069772.json",
+          "@type": "sc:Canvas",
+          "label": "Image 039",
+          "height": 2980,
+          "width": 2332,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069772.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2980,
+                "width": 2332,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069772.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069772.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069777.json",
+          "@type": "sc:Canvas",
+          "label": "Image 040",
+          "height": 2985,
+          "width": 2332,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069777.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2985,
+                "width": 2332,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069777.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069777.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069787.json",
+          "@type": "sc:Canvas",
+          "label": "Image 041",
+          "height": 3839,
+          "width": 2941,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069787.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3839,
+                "width": 2941,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069787.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069787.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069796.json",
+          "@type": "sc:Canvas",
+          "label": "Image 042",
+          "height": 2386,
+          "width": 2954,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069796.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2386,
+                "width": 2954,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069796.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069796.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069808.json",
+          "@type": "sc:Canvas",
+          "label": "Image 043",
+          "height": 2939,
+          "width": 2417,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069808.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2939,
+                "width": 2417,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069808.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069808.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069819.json",
+          "@type": "sc:Canvas",
+          "label": "Image 044",
+          "height": 2965,
+          "width": 2391,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069819.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2965,
+                "width": 2391,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069819.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069819.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069826.json",
+          "@type": "sc:Canvas",
+          "label": "Image 045",
+          "height": 2959,
+          "width": 2422,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069826.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2959,
+                "width": 2422,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069826.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069826.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069839.json",
+          "@type": "sc:Canvas",
+          "label": "Image 046",
+          "height": 2965,
+          "width": 2427,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069839.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2965,
+                "width": 2427,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069839.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069839.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069847.json",
+          "@type": "sc:Canvas",
+          "label": "Image 047",
+          "height": 4115,
+          "width": 3180,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069847.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4115,
+                "width": 3180,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069847.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069847.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069865.json",
+          "@type": "sc:Canvas",
+          "label": "Image 048",
+          "height": 3981,
+          "width": 3274,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069865.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3981,
+                "width": 3274,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069865.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069865.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069877.json",
+          "@type": "sc:Canvas",
+          "label": "Image 049",
+          "height": 3965,
+          "width": 3284,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069877.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3965,
+                "width": 3284,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069877.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069877.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069891.json",
+          "@type": "sc:Canvas",
+          "label": "Image 050",
+          "height": 4157,
+          "width": 3357,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069891.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4157,
+                "width": 3357,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069891.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069891.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069901.json",
+          "@type": "sc:Canvas",
+          "label": "Image 051",
+          "height": 4151,
+          "width": 3372,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069901.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4151,
+                "width": 3372,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069901.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069901.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069913.json",
+          "@type": "sc:Canvas",
+          "label": "Image 052",
+          "height": 3955,
+          "width": 3138,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069913.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3955,
+                "width": 3138,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069913.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069913.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069926.json",
+          "@type": "sc:Canvas",
+          "label": "Image 053",
+          "height": 3950,
+          "width": 3133,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069926.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3950,
+                "width": 3133,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069926.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069926.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069946.json",
+          "@type": "sc:Canvas",
+          "label": "Image 054",
+          "height": 2783,
+          "width": 2599,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069946.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2783,
+                "width": 2599,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069946.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069946.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069958.json",
+          "@type": "sc:Canvas",
+          "label": "Image 055",
+          "height": 2783,
+          "width": 2599,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069958.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2783,
+                "width": 2599,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069958.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069958.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069970.json",
+          "@type": "sc:Canvas",
+          "label": "Image 056",
+          "height": 2783,
+          "width": 2298,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069970.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2783,
+                "width": 2298,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069970.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069970.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069978.json",
+          "@type": "sc:Canvas",
+          "label": "Image 057",
+          "height": 2773,
+          "width": 2277,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069978.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2773,
+                "width": 2277,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069978.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069978.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069988.json",
+          "@type": "sc:Canvas",
+          "label": "Image 058",
+          "height": 4097,
+          "width": 3239,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069988.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4097,
+                "width": 3239,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2069988.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069988.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070002.json",
+          "@type": "sc:Canvas",
+          "label": "Image 059",
+          "height": 4087,
+          "width": 3239,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070002.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4087,
+                "width": 3239,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070002.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070002.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070012.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3951,
+          "width": 3091,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070012.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3951,
+                "width": 3091,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070012.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070012.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070020.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3951,
+          "width": 3091,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070020.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3951,
+                "width": 3091,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070020.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070020.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070027.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 3983,
+          "width": 3091,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070027.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3983,
+                "width": 3091,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070027.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070027.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070037.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 3977,
+          "width": 3085,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070037.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3977,
+                "width": 3085,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070037.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070037.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070046.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 3749,
+          "width": 3013,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070046.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3749,
+                "width": 3013,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070046.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070046.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070059.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 3749,
+          "width": 3008,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070059.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3749,
+                "width": 3008,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070059.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070059.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070081.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 3984,
+          "width": 3070,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070081.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3984,
+                "width": 3070,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070081.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070081.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070094.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 3973,
+          "width": 3059,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070094.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3973,
+                "width": 3059,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070094.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070094.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070106.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 3165,
+          "width": 2203,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070106.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3165,
+                "width": 2203,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070106.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070106.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070117.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 3838,
+          "width": 2977,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070117.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3838,
+                "width": 2977,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070117.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070117.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070127.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 4149,
+          "width": 3121,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070127.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4149,
+                "width": 3121,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070127.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070127.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070138.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 4144,
+          "width": 3116,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070138.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4144,
+                "width": 3116,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070138.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070138.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070155.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 2956,
+          "width": 2408,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070155.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2956,
+                "width": 2408,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070155.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070155.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070180.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 2956,
+          "width": 2408,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070180.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2956,
+                "width": 2408,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070180.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070180.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070196.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 3075,
+          "width": 2511,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070196.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3075,
+                "width": 2511,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070196.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070196.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070206.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 3080,
+          "width": 2511,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070206.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3080,
+                "width": 2511,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070206.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070206.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070220.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 2940,
+          "width": 2397,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070220.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2940,
+                "width": 2397,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070220.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070220.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070232.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 2940,
+          "width": 2397,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070232.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2940,
+                "width": 2397,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070232.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070232.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070244.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 3070,
+          "width": 2505,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070244.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3070,
+                "width": 2505,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070244.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070244.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070255.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 3076,
+          "width": 2516,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070255.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3076,
+                "width": 2516,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070255.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070255.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070266.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 3076,
+          "width": 2510,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070266.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3076,
+                "width": 2510,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070266.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070266.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070287.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 3065,
+          "width": 2495,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070287.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3065,
+                "width": 2495,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070287.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070287.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070302.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 3071,
+          "width": 2500,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070302.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3071,
+                "width": 2500,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070302.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070302.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070312.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 3071,
+          "width": 2500,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070312.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3071,
+                "width": 2500,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070312.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070312.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070323.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 4122,
+          "width": 3218,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070323.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4122,
+                "width": 3218,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070323.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070323.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070333.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 4117,
+          "width": 3218,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070333.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4117,
+                "width": 3218,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070333.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070333.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070345.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 3998,
+          "width": 2616,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070345.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3998,
+                "width": 2616,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070345.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070345.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070356.json",
+          "@type": "sc:Canvas",
+          "label": "Image 028",
+          "height": 4003,
+          "width": 2606,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070356.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4003,
+                "width": 2606,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070356.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070356.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070366.json",
+          "@type": "sc:Canvas",
+          "label": "Image 029",
+          "height": 3992,
+          "width": 3218,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070366.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3992,
+                "width": 3218,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070366.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070366.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070378.json",
+          "@type": "sc:Canvas",
+          "label": "Image 030",
+          "height": 3992,
+          "width": 3202,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070378.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3992,
+                "width": 3202,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070378.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070378.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070396.json",
+          "@type": "sc:Canvas",
+          "label": "Image 031",
+          "height": 3077,
+          "width": 2485,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070396.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3077,
+                "width": 2485,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070396.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070396.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070408.json",
+          "@type": "sc:Canvas",
+          "label": "Image 032",
+          "height": 3077,
+          "width": 2475,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070408.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3077,
+                "width": 2475,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070408.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070408.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070420.json",
+          "@type": "sc:Canvas",
+          "label": "Image 033",
+          "height": 3076,
+          "width": 2454,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070420.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3076,
+                "width": 2454,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070420.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070420.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070426.json",
+          "@type": "sc:Canvas",
+          "label": "Image 034",
+          "height": 3076,
+          "width": 2443,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070426.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3076,
+                "width": 2443,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070426.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070426.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070440.json",
+          "@type": "sc:Canvas",
+          "label": "Image 035",
+          "height": 3045,
+          "width": 2475,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070440.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3045,
+                "width": 2475,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070440.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070440.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070451.json",
+          "@type": "sc:Canvas",
+          "label": "Image 036",
+          "height": 3056,
+          "width": 2485,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070451.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3056,
+                "width": 2485,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070451.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070451.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070463.json",
+          "@type": "sc:Canvas",
+          "label": "Image 037",
+          "height": 3082,
+          "width": 2464,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070463.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3082,
+                "width": 2464,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070463.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070463.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070478.json",
+          "@type": "sc:Canvas",
+          "label": "Image 038",
+          "height": 3082,
+          "width": 2464,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070478.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3082,
+                "width": 2464,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070478.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070478.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070491.json",
+          "@type": "sc:Canvas",
+          "label": "Image 039",
+          "height": 2998,
+          "width": 2397,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070491.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2998,
+                "width": 2397,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070491.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070491.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070502.json",
+          "@type": "sc:Canvas",
+          "label": "Image 040",
+          "height": 3004,
+          "width": 2408,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070502.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3004,
+                "width": 2408,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070502.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070502.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070514.json",
+          "@type": "sc:Canvas",
+          "label": "Image 041",
+          "height": 3071,
+          "width": 2392,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070514.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3071,
+                "width": 2392,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070514.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070514.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070527.json",
+          "@type": "sc:Canvas",
+          "label": "Image 042",
+          "height": 3081,
+          "width": 2402,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070527.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3081,
+                "width": 2402,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070527.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070527.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070538.json",
+          "@type": "sc:Canvas",
+          "label": "Image 043",
+          "height": 2965,
+          "width": 2054,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070538.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2965,
+                "width": 2054,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070538.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070538.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070548.json",
+          "@type": "sc:Canvas",
+          "label": "Image 044",
+          "height": 3042,
+          "width": 2979,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070548.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3042,
+                "width": 2979,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070548.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070548.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070562.json",
+          "@type": "sc:Canvas",
+          "label": "Image 045",
+          "height": 2148,
+          "width": 3070,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070562.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2148,
+                "width": 3070,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070562.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070562.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070571.json",
+          "@type": "sc:Canvas",
+          "label": "Image 046",
+          "height": 2130,
+          "width": 3061,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070571.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2130,
+                "width": 3061,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070571.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070571.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070586.json",
+          "@type": "sc:Canvas",
+          "label": "Image 047",
+          "height": 3061,
+          "width": 2426,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070586.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3061,
+                "width": 2426,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070586.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070586.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070596.json",
+          "@type": "sc:Canvas",
+          "label": "Image 048",
+          "height": 3071,
+          "width": 2436,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070596.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3071,
+                "width": 2436,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070596.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070596.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070610.json",
+          "@type": "sc:Canvas",
+          "label": "Image 049",
+          "height": 3056,
+          "width": 2203,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070610.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3056,
+                "width": 2203,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070610.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070610.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070621.json",
+          "@type": "sc:Canvas",
+          "label": "Image 050",
+          "height": 3061,
+          "width": 2197,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070621.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3061,
+                "width": 2197,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070621.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070621.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070631.json",
+          "@type": "sc:Canvas",
+          "label": "Image 051",
+          "height": 3061,
+          "width": 2337,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070631.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3061,
+                "width": 2337,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070631.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070631.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070644.json",
+          "@type": "sc:Canvas",
+          "label": "Image 052",
+          "height": 3071,
+          "width": 2337,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070644.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3071,
+                "width": 2337,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070644.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070644.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070655.json",
+          "@type": "sc:Canvas",
+          "label": "Image 053",
+          "height": 3045,
+          "width": 2327,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070655.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3045,
+                "width": 2327,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070655.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070655.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070666.json",
+          "@type": "sc:Canvas",
+          "label": "Image 054",
+          "height": 3067,
+          "width": 2347,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070666.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3067,
+                "width": 2347,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070666.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070666.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070680.json",
+          "@type": "sc:Canvas",
+          "label": "Image 055",
+          "height": 4491,
+          "width": 3598,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070680.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4491,
+                "width": 3598,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070680.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070680.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070689.json",
+          "@type": "sc:Canvas",
+          "label": "Image 056",
+          "height": 4491,
+          "width": 3598,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070689.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4491,
+                "width": 3598,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070689.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070689.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070700.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3070,
+          "width": 2681,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070700.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3070,
+                "width": 2681,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070700.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070700.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070709.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3064,
+          "width": 2670,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070709.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3064,
+                "width": 2670,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070709.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070709.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070722.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 3661,
+          "width": 3053,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070722.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3661,
+                "width": 3053,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070722.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070722.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070730.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 3651,
+          "width": 3048,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070730.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3651,
+                "width": 3048,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070730.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070730.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070742.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 3357,
+          "width": 2617,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070742.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3357,
+                "width": 2617,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070742.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070742.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070750.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 3357,
+          "width": 2616,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070750.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3357,
+                "width": 2616,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070750.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070750.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070775.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 3373,
+          "width": 2617,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070775.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3373,
+                "width": 2617,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070775.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070775.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070789.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 4141,
+          "width": 3124,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070789.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4141,
+                "width": 3124,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070789.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070789.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070803.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 4146,
+          "width": 3124,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070803.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4146,
+                "width": 3124,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070803.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070803.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070811.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 4161,
+          "width": 2937,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070811.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4161,
+                "width": 2937,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070811.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070811.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070818.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 4161,
+          "width": 2937,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070818.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4161,
+                "width": 2937,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070818.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070818.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070832.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 4203,
+          "width": 3238,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070832.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4203,
+                "width": 3238,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070832.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070832.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070843.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 4227,
+          "width": 3020,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070843.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4227,
+                "width": 3020,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070843.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070843.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070857.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 4232,
+          "width": 3014,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070857.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4232,
+                "width": 3014,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070857.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070857.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070869.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4163,
+          "width": 3247,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070869.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4163,
+                "width": 3247,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070869.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070869.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070883.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 4158,
+          "width": 3237,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070883.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4158,
+                "width": 3237,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070883.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070883.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070916.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 3374,
+          "width": 2635,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070916.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3374,
+                "width": 2635,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070916.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070916.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070933.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 3369,
+          "width": 2630,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070933.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3369,
+                "width": 2630,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070933.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070933.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070944.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 3447,
+          "width": 2744,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070944.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3447,
+                "width": 2744,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070944.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070944.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070960.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 4243,
+          "width": 3237,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070960.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4243,
+                "width": 3237,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070960.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070960.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070971.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 3855,
+          "width": 2916,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070971.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3855,
+                "width": 2916,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070971.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070971.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070979.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 3850,
+          "width": 2916,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070979.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3850,
+                "width": 2916,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070979.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070979.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070996.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 4187,
+          "width": 3305,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070996.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4187,
+                "width": 3305,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2070996.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070996.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071010.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 4187,
+          "width": 3300,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071010.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4187,
+                "width": 3300,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071010.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071010.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071021.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 4187,
+          "width": 3227,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071021.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4187,
+                "width": 3227,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071021.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071021.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071042.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 4176,
+          "width": 3191,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071042.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4176,
+                "width": 3191,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071042.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071042.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071053.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 4171,
+          "width": 3186,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071053.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4171,
+                "width": 3186,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071053.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071053.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071064.json",
+          "@type": "sc:Canvas",
+          "label": "Image 028",
+          "height": 4046,
+          "width": 2936,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071064.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4046,
+                "width": 2936,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071064.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071064.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071076.json",
+          "@type": "sc:Canvas",
+          "label": "Image 029",
+          "height": 4068,
+          "width": 2932,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071076.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4068,
+                "width": 2932,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071076.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071076.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071090.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3357,
+          "width": 3718,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071090.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3357,
+                "width": 3718,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071090.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071090.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071104.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3352,
+          "width": 3705,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071104.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3352,
+                "width": 3705,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071104.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071104.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071119.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 3404,
+          "width": 2984,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071119.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3404,
+                "width": 2984,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071119.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071119.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071134.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 3394,
+          "width": 2973,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071134.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3394,
+                "width": 2973,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071134.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071134.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071145.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 2691,
+          "width": 2121,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071145.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2691,
+                "width": 2121,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071145.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071145.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071158.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 2712,
+          "width": 2126,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071158.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2712,
+                "width": 2126,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071158.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071158.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071167.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 4179,
+          "width": 2973,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071167.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4179,
+                "width": 2973,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071167.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071167.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071183.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 4174,
+          "width": 3025,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071183.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4174,
+                "width": 3025,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071183.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071183.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071193.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 4137,
+          "width": 3123,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071193.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4137,
+                "width": 3123,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071193.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071193.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071207.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 4132,
+          "width": 3113,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071207.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4132,
+                "width": 3113,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071207.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071207.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071216.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 4075,
+          "width": 3175,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071216.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4075,
+                "width": 3175,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071216.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071216.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071226.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 4075,
+          "width": 3175,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071226.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4075,
+                "width": 3175,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071226.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071226.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071237.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 4117,
+          "width": 3148,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071237.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4117,
+                "width": 3148,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071237.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071237.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071245.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 4117,
+          "width": 3143,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071245.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4117,
+                "width": 3143,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071245.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071245.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071256.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 4117,
+          "width": 3143,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071256.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4117,
+                "width": 3143,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071256.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071256.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071273.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 4123,
+          "width": 3143,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071273.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4123,
+                "width": 3143,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071273.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071273.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071285.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 4102,
+          "width": 3143,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071285.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4102,
+                "width": 3143,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071285.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071285.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071299.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 4107,
+          "width": 3137,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071299.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4107,
+                "width": 3137,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071299.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071299.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071314.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 3832,
+          "width": 2821,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071314.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3832,
+                "width": 2821,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071314.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071314.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071324.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 4143,
+          "width": 3251,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071324.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4143,
+                "width": 3251,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071324.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071324.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071342.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 4029,
+          "width": 3241,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071342.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4029,
+                "width": 3241,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071342.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071342.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071354.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 4143,
+          "width": 3231,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071354.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4143,
+                "width": 3231,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071354.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071354.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071364.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 4143,
+          "width": 3236,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071364.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4143,
+                "width": 3236,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071364.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071364.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071375.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 2987,
+          "width": 2370,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071375.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2987,
+                "width": 2370,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071375.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071375.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071386.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 2950,
+          "width": 2349,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071386.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2950,
+                "width": 2349,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071386.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071386.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071400.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 2950,
+          "width": 2349,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071400.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2950,
+                "width": 2349,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071400.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071400.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071410.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 2961,
+          "width": 2339,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071410.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2961,
+                "width": 2339,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071410.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071410.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071423.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 2966,
+          "width": 2339,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071423.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2966,
+                "width": 2339,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071423.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071423.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071436.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 3379,
+          "width": 2650,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071436.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3379,
+                "width": 2650,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071436.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071436.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071451.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 3784,
+          "width": 3310,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071451.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3784,
+                "width": 3310,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071451.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071451.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071462.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 3785,
+          "width": 3298,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071462.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3785,
+                "width": 3298,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071462.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071462.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071471.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 3080,
+          "width": 2494,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071471.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3080,
+                "width": 2494,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071471.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071471.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071486.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 3075,
+          "width": 2499,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071486.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3075,
+                "width": 2499,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071486.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071486.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071494.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 3070,
+          "width": 2489,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071494.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3070,
+                "width": 2489,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071494.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071494.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071506.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 3075,
+          "width": 2500,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071506.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3075,
+                "width": 2500,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071506.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071506.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071518.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 2655,
+          "width": 2448,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071518.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2655,
+                "width": 2448,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071518.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071518.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071528.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 2645,
+          "width": 2442,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071528.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2645,
+                "width": 2442,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071528.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071528.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071536.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 4096,
+          "width": 3227,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071536.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4096,
+                "width": 3227,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071536.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071536.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071549.json",
+          "@type": "sc:Canvas",
+          "label": "Image 020",
+          "height": 4096,
+          "width": 3237,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071549.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4096,
+                "width": 3237,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071549.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071549.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071560.json",
+          "@type": "sc:Canvas",
+          "label": "Image 021",
+          "height": 3920,
+          "width": 3164,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071560.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3920,
+                "width": 3164,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071560.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071560.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071575.json",
+          "@type": "sc:Canvas",
+          "label": "Image 022",
+          "height": 3920,
+          "width": 3170,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071575.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3920,
+                "width": 3170,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071575.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071575.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071585.json",
+          "@type": "sc:Canvas",
+          "label": "Image 023",
+          "height": 4443,
+          "width": 2945,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071585.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4443,
+                "width": 2945,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071585.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071585.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071597.json",
+          "@type": "sc:Canvas",
+          "label": "Image 024",
+          "height": 4433,
+          "width": 2940,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071597.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4433,
+                "width": 2940,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071597.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071597.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071608.json",
+          "@type": "sc:Canvas",
+          "label": "Image 025",
+          "height": 4183,
+          "width": 2817,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071608.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4183,
+                "width": 2817,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071608.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071608.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071626.json",
+          "@type": "sc:Canvas",
+          "label": "Image 026",
+          "height": 4183,
+          "width": 2817,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071626.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4183,
+                "width": 2817,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071626.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071626.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071634.json",
+          "@type": "sc:Canvas",
+          "label": "Image 027",
+          "height": 4229,
+          "width": 3215,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071634.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4229,
+                "width": 3215,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071634.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071634.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071648.json",
+          "@type": "sc:Canvas",
+          "label": "Image 028",
+          "height": 4234,
+          "width": 3216,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071648.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4234,
+                "width": 3216,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071648.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071648.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071656.json",
+          "@type": "sc:Canvas",
+          "label": "Image 029",
+          "height": 3835,
+          "width": 2946,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071656.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3835,
+                "width": 2946,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071656.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071656.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071666.json",
+          "@type": "sc:Canvas",
+          "label": "Image 030",
+          "height": 2351,
+          "width": 2951,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071666.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2351,
+                "width": 2951,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071666.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071666.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071676.json",
+          "@type": "sc:Canvas",
+          "label": "Image 031",
+          "height": 2347,
+          "width": 2956,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071676.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2347,
+                "width": 2956,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071676.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071676.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071689.json",
+          "@type": "sc:Canvas",
+          "label": "Image 032",
+          "height": 4110,
+          "width": 2911,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071689.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4110,
+                "width": 2911,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071689.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071689.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071699.json",
+          "@type": "sc:Canvas",
+          "label": "Image 033",
+          "height": 4110,
+          "width": 2911,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071699.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4110,
+                "width": 2911,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071699.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071699.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071708.json",
+          "@type": "sc:Canvas",
+          "label": "Image 034",
+          "height": 4182,
+          "width": 3072,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071708.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4182,
+                "width": 3072,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071708.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071708.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071717.json",
+          "@type": "sc:Canvas",
+          "label": "Image 035",
+          "height": 4172,
+          "width": 3072,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071717.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4172,
+                "width": 3072,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071717.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071717.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071728.json",
+          "@type": "sc:Canvas",
+          "label": "Image 001",
+          "height": 3070,
+          "width": 2499,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071728.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3070,
+                "width": 2499,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071728.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071728.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071737.json",
+          "@type": "sc:Canvas",
+          "label": "Image 002",
+          "height": 3070,
+          "width": 2505,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071737.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3070,
+                "width": 2505,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071737.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071737.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071748.json",
+          "@type": "sc:Canvas",
+          "label": "Image 003",
+          "height": 3308,
+          "width": 2505,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071748.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3308,
+                "width": 2505,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071748.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071748.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071759.json",
+          "@type": "sc:Canvas",
+          "label": "Image 004",
+          "height": 3303,
+          "width": 2499,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071759.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3303,
+                "width": 2499,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071759.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071759.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071769.json",
+          "@type": "sc:Canvas",
+          "label": "Image 005",
+          "height": 3693,
+          "width": 2768,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071769.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 3693,
+                "width": 2768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071769.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071769.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071782.json",
+          "@type": "sc:Canvas",
+          "label": "Image 006",
+          "height": 2869,
+          "width": 2280,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071782.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2869,
+                "width": 2280,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071782.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071782.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071793.json",
+          "@type": "sc:Canvas",
+          "label": "Image 007",
+          "height": 2869,
+          "width": 2274,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071793.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2869,
+                "width": 2274,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071793.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071793.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071808.json",
+          "@type": "sc:Canvas",
+          "label": "Image 008",
+          "height": 4036,
+          "width": 3051,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071808.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4036,
+                "width": 3051,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071808.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071808.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071822.json",
+          "@type": "sc:Canvas",
+          "label": "Image 009",
+          "height": 4041,
+          "width": 3051,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071822.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4041,
+                "width": 3051,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071822.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071822.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071833.json",
+          "@type": "sc:Canvas",
+          "label": "Image 010",
+          "height": 4057,
+          "width": 3279,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071833.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4057,
+                "width": 3279,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071833.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071833.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071844.json",
+          "@type": "sc:Canvas",
+          "label": "Image 011",
+          "height": 4062,
+          "width": 3274,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071844.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4062,
+                "width": 3274,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071844.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071844.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071855.json",
+          "@type": "sc:Canvas",
+          "label": "Image 012",
+          "height": 4031,
+          "width": 3217,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071855.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4031,
+                "width": 3217,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071855.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071855.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071866.json",
+          "@type": "sc:Canvas",
+          "label": "Image 013",
+          "height": 4026,
+          "width": 3202,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071866.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4026,
+                "width": 3202,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071866.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071866.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071875.json",
+          "@type": "sc:Canvas",
+          "label": "Image 014",
+          "height": 4031,
+          "width": 3170,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071875.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4031,
+                "width": 3170,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071875.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071875.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071889.json",
+          "@type": "sc:Canvas",
+          "label": "Image 015",
+          "height": 4031,
+          "width": 3165,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071889.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4031,
+                "width": 3165,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071889.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071889.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071901.json",
+          "@type": "sc:Canvas",
+          "label": "Image 016",
+          "height": 2005,
+          "width": 1438,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071901.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2005,
+                "width": 1438,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071901.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071901.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071925.json",
+          "@type": "sc:Canvas",
+          "label": "Image 017",
+          "height": 2005,
+          "width": 1443,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071925.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 2005,
+                "width": 1443,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071925.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071925.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071938.json",
+          "@type": "sc:Canvas",
+          "label": "Image 018",
+          "height": 4537,
+          "width": 3295,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071938.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4537,
+                "width": 3295,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071938.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071938.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071942.json",
+          "@type": "sc:Canvas",
+          "label": "Image 019",
+          "height": 4543,
+          "width": 3300,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071942.jp2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4543,
+                "width": 3300,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://iiifdev.getty.edu/loris/gri%2F2007d1_d2941%2FFL2071942.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071942.json"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-1.json",
+      "@type": "sc:Range",
+      "label": "Sculptures: Italian, undated",
+      "viewingHint": "top",
+      "ranges": [
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-2.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-3.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-4.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-5.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-6.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-7.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-8.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-9.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-10.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-11.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-12.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-13.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-14.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-15.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/range/range-16.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-2.json",
+      "@type": "sc:Range",
+      "label": "Amadeo-bambaia  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067697.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067706.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067718.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067731.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067741.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067749.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067754.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067761.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067770.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067777.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067785.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067793.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067802.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067807.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067816.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-3.json",
+      "@type": "sc:Range",
+      "label": "Benedetto da Maiano  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067826.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067835.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067844.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067849.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067859.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067868.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067875.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067882.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067889.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067900.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067909.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067921.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067931.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067948.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067954.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067960.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067972.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-4.json",
+      "@type": "sc:Range",
+      "label": "Bernini - Civitali  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067980.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067989.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2067999.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068007.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068015.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068024.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068032.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068040.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068048.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068056.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068061.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068068.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068076.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068082.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068086.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068093.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068098.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068106.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068111.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068117.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068126.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068133.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068138.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068147.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068153.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068158.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068166.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068173.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068179.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068186.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068192.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068198.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068206.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068213.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068220.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068230.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068241.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-5.json",
+      "@type": "sc:Range",
+      "label": "Desiderio da Settignano  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068250.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068259.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068268.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068279.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068290.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068299.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068308.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068318.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068327.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068334.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068337.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068341.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068345.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068350.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068354.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068358.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068363.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068367.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068371.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068374.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068378.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068382.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068386.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068390.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068395.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068399.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068405.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068409.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068413.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-6.json",
+      "@type": "sc:Range",
+      "label": "Donatello  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068417.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068424.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068432.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068440.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068448.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068456.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068462.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068475.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068482.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068492.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068498.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068507.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068515.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068523.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068531.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068539.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068545.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068554.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068561.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068569.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068577.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068588.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068596.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068602.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068611.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068621.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068630.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-7.json",
+      "@type": "sc:Range",
+      "label": "Francesco di Giorgio Martini-Giambologna  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068637.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068649.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068656.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068666.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068674.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068684.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068693.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068706.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068713.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068727.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068737.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068749.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068755.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068763.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068774.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068784.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068794.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068801.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068812.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-8.json",
+      "@type": "sc:Range",
+      "label": "Laurana-School of Michelangelo  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068817.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068823.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068835.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068846.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068855.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068865.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068874.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068884.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068892.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068901.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068909.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068917.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068921.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068931.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068941.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068959.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068967.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068975.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068983.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068991.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2068998.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069006.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069014.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-9.json",
+      "@type": "sc:Range",
+      "label": "Mino da Fiesole  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069023.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069033.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069040.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069058.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069068.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069079.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069089.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069096.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069108.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069116.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069136.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069144.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069153.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069162.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069169.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069177.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069184.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069194.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069204.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069210.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069219.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069236.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069246.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069256.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069264.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069275.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069285.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069294.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069302.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069313.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069333.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069345.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069349.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069371.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069380.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069389.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069398.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069407.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-10.json",
+      "@type": "sc:Range",
+      "label": "Pollaiuolo-Riccio  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069417.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069424.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069432.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069442.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069453.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069459.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069469.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069479.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069487.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069497.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069504.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069511.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069519.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069535.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069542.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069555.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069564.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069570.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069578.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069586.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069595.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069607.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069619.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069628.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069637.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069646.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069654.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069662.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069678.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069686.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069694.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069700.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069709.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069717.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069727.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069737.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069746.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069761.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069772.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069777.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069787.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069796.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069808.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069819.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069826.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069839.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069847.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069865.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069877.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069891.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069901.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069913.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069926.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069946.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069958.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069970.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069978.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2069988.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070002.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-11.json",
+      "@type": "sc:Range",
+      "label": "Rossellino  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070012.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070020.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070027.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070037.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070046.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070059.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070081.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070094.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070106.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070117.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070127.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070138.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070155.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070180.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070196.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070206.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070220.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070232.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070244.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070255.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070266.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070287.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070302.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070312.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070323.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070333.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070345.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070356.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070366.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070378.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070396.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070408.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070420.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070426.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070440.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070451.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070463.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070478.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070491.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070502.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070514.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070527.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070538.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070548.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070562.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070571.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070586.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070596.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070610.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070621.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070631.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070644.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070655.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070666.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070680.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070689.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-12.json",
+      "@type": "sc:Range",
+      "label": "Sansovino  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070700.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070709.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070722.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070730.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070742.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070750.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070775.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070789.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070803.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070811.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070818.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070832.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070843.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070857.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070869.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070883.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070916.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070933.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070944.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070960.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070971.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070979.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2070996.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071010.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071021.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071042.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071053.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071064.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071076.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-13.json",
+      "@type": "sc:Range",
+      "label": "Solari-Tino di Camaino  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071090.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071104.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071119.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071134.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071145.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071158.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071167.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071183.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071193.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071207.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071216.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071226.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-14.json",
+      "@type": "sc:Range",
+      "label": "Tuscan-Venetian  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071237.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071245.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071256.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071273.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071285.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071299.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071314.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-15.json",
+      "@type": "sc:Range",
+      "label": "Verrocchio  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071324.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071342.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071354.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071364.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071375.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071386.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071400.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071410.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071423.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071436.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071451.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071462.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071471.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071486.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071494.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071506.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071518.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071528.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071536.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071549.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071560.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071575.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071585.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071597.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071608.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071626.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071634.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071648.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071656.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071666.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071676.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071689.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071699.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071708.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071717.json"
+      ]
+    },
+    {
+      "@id": "http://data.getty.edu/iiif/2007d1_d2941/range/range-16.json",
+      "@type": "sc:Range",
+      "label": "Vittoria  ",
+      "canvases": [
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071728.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071737.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071748.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071759.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071769.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071782.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071793.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071808.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071822.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071833.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071844.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071855.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071866.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071875.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071889.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071901.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071925.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071938.json",
+        "http://data.getty.edu/iiif/2007d1_d2941/canvas/canvas-FL2071942.json"
+      ]
+    }
+  ]
+}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -40,7 +40,7 @@ class TestAll(unittest.TestCase):
         self.assertEqual( mf.context_uri, 'http://www.shared-canvas.org/ns/context.json' )
 
     def test05_multipleContexts(self):
-        fh = file('tests/multiple_contexts_fixture.json')
+        fh = open('tests/multiple_contexts_fixture.json')
         data = fh.read()
         fh.close()
         js = json.loads(data)
@@ -48,7 +48,7 @@ class TestAll(unittest.TestCase):
         doc = mr.read()
 
     def test06_range_range(self):
-        fh = file('tests/range_range_fixture.json')
+        fh = open('tests/range_range_fixture.json')
         data = fh.read()
         fh.close()
         js = json.loads(data)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 import re
 import unittest
+import json
 
 from iiif_prezi.loader import SerializationError, load_document_local, ManifestReader
 
@@ -38,3 +39,18 @@ class TestAll(unittest.TestCase):
         mf = mr.buildFactory('2')
         self.assertEqual( mf.context_uri, 'http://www.shared-canvas.org/ns/context.json' )
 
+    def test05_multipleContexts(self):
+        fh = file('tests/multiple_contexts_fixture.json')
+        data = fh.read()
+        fh.close()
+        js = json.loads(data)
+        mr = ManifestReader(js)
+        doc = mr.read()
+
+    def test06_range_range(self):
+        fh = file('tests/range_range_fixture.json')
+        data = fh.read()
+        fh.close()
+        js = json.loads(data)
+        mr = ManifestReader(js)
+        doc = mr.read()


### PR DESCRIPTION

There isn't a fixture for a range including another range. This PR fixes the bug found by @alyxrossetti via the new manifest in the tests/ directory