### PR TITLE
Fix for label/value handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,12 @@ python:
   - "3.5"
 # commands to install dependencies
 install:
-  - pip install coveralls pep257 restructuredtext_lint testfixtures
+  - pip install coveralls pep257 testfixtures
   - python setup.py install
 # commands to run tests
 script:
   - py.test
   - pep257 *.py iiif_prezi/*.py
-  - rst-lint README
   - coverage run --source=iiif_prezi setup.py test
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ python:
   - "3.4"
   - "3.5"
 # commands to install dependencies
-# need "python setup.py install" to install resync so that client tests work
 install:
-  - pip install Pillow coveralls pep257 restructuredtext_lint testfixtures
+  - pip install coveralls pep257 restructuredtext_lint testfixtures
   - python setup.py install
 # commands to run tests
 script:

--- a/check_remote_manifests.py
+++ b/check_remote_manifests.py
@@ -1,37 +1,63 @@
 """Test code for iiif_prezi.loader using remote data."""
 
+import os
+import sys
+import optparse
+try:
+    # python3
+    from urllib.request import urlopen
+except ImportError:
+    # fall back to python2
+    from urllib2 import urlopen
 from iiif_prezi.loader import ManifestReader
-import urllib, os, sys
 
-def test_remote():
-	"""Test a list or remote Manifest URLs."""
-	urls = [
-	 #"http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json",
-	 #"http://manifests.ydc2.yale.edu/manifest/Admont23.json",
-	 #"http://oculus-dev.lib.harvard.edu/manifests/drs:5981093",
-	 #"http://iiif-dev.bodleian.ox.ac.uk/metadata/bib_germ_1485_d1/bib_germ_1485_d1.json",
-	 #"http://iiif-dev.bodleian.ox.ac.uk/metadata/ms_auct_t_inf_2_1/ms_auct_t_inf_2_1.json",
-	 #"http://demos.biblissima-condorcet.fr/iiif/metadata/ark:/12148/btv1b84473026/manifest.json",
-	 #"http://demos.biblissima-condorcet.fr/iiif/metadata/ark:/12148/btv1b84473026/manifest-ranges.json",
-	 #"http://demos.biblissima-condorcet.fr/mirador/data/add_ms_10289_edited_8v-9r.json",
-	 #"http://demos.biblissima-condorcet.fr/iiif/metadata/ark:/12148/btv1b8438674r/manifest.json",
-	 "http://demos.biblissima-condorcet.fr/iiif/metadata/BVH/B410186201_LI03/manifest.json",
-	 "http://sanddragon.bl.uk/IIIFMetadataService/add_ms_10289.json",
-	 "http://sr-svx-93.unifr.ch/metadata/iiif/bbb-0218/manifest.json",
-	 #"http://www.shared-canvas.org/impl/demo1d/res/manifest.json"
-	]
-	for u in urls:
-		fh = urllib.urlopen(u)
-		data = fh.read()
-		fh.close()
-		try:
-			print("------")
-			print(u)
-			reader = ManifestReader(data)
-			nmfst = reader.read()
-			js = nmfst.toJSON()
-		except Exception as e:
-			print("   => %s: %s" % (e.__class__.__name__, e))
+
+TESTSET = [
+    # "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json",
+    # "http://manifests.ydc2.yale.edu/manifest/Admont23.json",
+    # "http://oculus-dev.lib.harvard.edu/manifests/drs:5981093",
+    # "http://iiif-dev.bodleian.ox.ac.uk/metadata/bib_germ_1485_d1/bib_germ_1485_d1.json",
+    # "http://iiif-dev.bodleian.ox.ac.uk/metadata/ms_auct_t_inf_2_1/ms_auct_t_inf_2_1.json",
+    # "http://demos.biblissima-condorcet.fr/iiif/metadata/ark:/12148/btv1b84473026/manifest.json",
+    # "http://demos.biblissima-condorcet.fr/iiif/metadata/ark:/12148/btv1b84473026/manifest-ranges.json",
+    # "http://demos.biblissima-condorcet.fr/mirador/data/add_ms_10289_edited_8v-9r.json",
+    # "http://demos.biblissima-condorcet.fr/iiif/metadata/ark:/12148/btv1b8438674r/manifest.json",
+    "http://demos.biblissima-condorcet.fr/iiif/metadata/BVH/B410186201_LI03/manifest.json",
+    "http://sanddragon.bl.uk/IIIFMetadataService/add_ms_10289.json",
+    "http://sr-svx-93.unifr.ch/metadata/iiif/bbb-0218/manifest.json",
+    # "http://www.shared-canvas.org/impl/demo1d/res/manifest.json"
+]
+
+
+def read_args():
+    """Read command line arguments."""
+    p = optparse.OptionParser(description='Check remote manifests by reading with iiif-prezi',
+                              usage='usage: %prog [options] [[url]]  (-h for help)')
+    p.add_option('--testset', '-t', action='store_true',
+                 help='Run against embedded testset')
+    (opt, args) = p.parse_args()
+    urls = list(args)
+    if (opt.testset):
+        urls.append(TESTSET)
+    if (len(urls) == 0):
+        raise Exception("Nothing to check (-h for help)")
+    return(urls)
+
+
+def test_remote(urls):
+    """Test a list or remote Manifest URLs."""
+    for u in urls:
+        fh = urlopen(u)
+        data = fh.read()
+        fh.close()
+        try:
+            print("------")
+            print(u)
+            reader = ManifestReader(data)
+            nmfst = reader.read()
+            js = nmfst.toJSON()
+        except Exception as e:
+            print("   => %s: %s" % (e.__class__.__name__, e))
 
 if __name__ == "__main__":
-    test_remote()
+    test_remote(read_args())

--- a/iiif_prezi/loader.py
+++ b/iiif_prezi/loader.py
@@ -332,12 +332,12 @@ class ManifestReader(object):
 						il = item['label']
 						if type(il) == dict:
 							il = self.jsonld_to_langhash(il)
+							lh = {'label': il, 'value': iv}
 						elif type(il) == list:
 							# oh man :(
-							lh = {'label':il, 'value':iv}
+							lh = {'label': il, 'value': iv}
 						else:
 							lh = {il: iv}
-
 						what.set_metadata(lh)
 				else:
 					# Actually this is an error

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ class Coverage(Command):
 
 install_requires=[
     "lxml",
-    "Pillow",
+    "Pillow>=3.2.0,<4.0.0",  # Pillow 4.0.0 drops python 2.6 support
     "pyld",
 ]
 if (sys.version_info[0:2] < (2,7)):

--- a/tests/label_value_language_fixture.json
+++ b/tests/label_value_language_fixture.json
@@ -3,7 +3,13 @@
  "@id": "http://example.org/testy-test-manifest",
  "@type": "sc:Manifest",
  "label": {"@language": "en", "@value": "Test Manifest"},
- "metadata": [{"label": {"@language": "en", "@value": "Name"},
+ "metadata": [{"label": "Notes", "value": ["Text of note 1", "Text of note 2"]},
+              {"label": "Published", "value": [
+                  {"@value": "Paris, circa 1400", "@language": "en"},
+                  {"@value": "Paris, environ 1400", "@language": "fr"}
+                ]
+              }, 
+              {"label": {"@language": "en", "@value": "Name"},
                "value": {"@language": "en", "@value": "Jack"}}],
  "sequences": [
       {

--- a/tests/label_value_language_fixture.json
+++ b/tests/label_value_language_fixture.json
@@ -1,0 +1,43 @@
+{
+ "@context": "http://iiif.io/api/presentation/2/context.json",
+ "@id": "http://example.org/testy-test-manifest",
+ "@type": "sc:Manifest",
+ "label": {"@language": "en", "@value": "Test Manifest"},
+ "metadata": [{"label": {"@language": "en", "@value": "Name"},
+               "value": {"@language": "en", "@value": "Jack"}}],
+ "sequences": [
+      {
+        "@id": "http://example.org/iiif/book1/sequence/normal",
+        "@type": "sc:Sequence",
+        "label": "Current Page Order",
+        "canvases": [
+          {
+            "@id": "http://example.org/iiif/book1/canvas/p1",
+            "@type": "sc:Canvas",
+            "label": "p. 1",
+            "height":1000,
+            "width":750,
+            "images": [
+              {
+                "@type": "oa:Annotation",
+                "motivation": "sc:painting",
+                "resource":{
+                    "@id": "http://example.org/iiif/book1/res/page1.jpg",
+                    "@type": "dctypes:Image",
+                    "format": "image/jpeg",
+                    "service": {
+                        "@context": "http://iiif.io/api/image/2/context.json",
+                        "@id": "http://example.org/images/book1-page1",
+                        "profile": "http://iiif.io/api/image/2/level1.json"
+                    },
+                    "height":2000,
+                    "width":1500
+                },
+                "on": "http://example.org/iiif/book1/canvas/p1"
+              }
+            ]
+          }
+        ]
+      }
+ ]
+}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -54,3 +54,11 @@ class TestAll(unittest.TestCase):
         js = json.loads(data)
         mr = ManifestReader(js)
         doc = mr.read()
+
+    def test07_label_value_language(self):
+        fh = open('tests/label_value_language_fixture.json')
+        data = fh.read()
+        fh.close()
+        js = json.loads(data)
+        mr = ManifestReader(js)
+        doc = mr.read()


### PR DESCRIPTION
Fixes #27.

It seems that restruucturetest-lint (https://pypi.python.org/pypi/restructuredtext_lint) no longer supports python2.6 (and a quick look suggests that it would be non-trivial to add that back) so I have removed checks on the REAME from travis.

Also tied Pillow to <4.0.0 to maintain python2.6 support...