### PR TITLE
set non {} non html lang value in supplied list

### DIFF
--- a/iiif_prezi/factory.py
+++ b/iiif_prezi/factory.py
@@ -583,7 +583,6 @@ class BaseMetadataObject(object):
 
     def _set_magic(self, which, value, html=True):
         """Magical handling of languages for string properties."""
-
         if type(value) in STR_TYPES:
             if self._factory.add_lang:
                 value = self.langhash_to_jsonld(

--- a/iiif_prezi/factory.py
+++ b/iiif_prezi/factory.py
@@ -583,6 +583,7 @@ class BaseMetadataObject(object):
 
     def _set_magic(self, which, value, html=True):
         """Magical handling of languages for string properties."""
+
         if type(value) in STR_TYPES:
             if self._factory.add_lang:
                 value = self.langhash_to_jsonld(
@@ -600,8 +601,9 @@ class BaseMetadataObject(object):
                     if self._factory.add_lang:
                         nl.extend(self.langhash_to_jsonld(
                             {self._factory.default_lang: i}, html))
-                    elif value and value[0] == '<' and value[-1] == '>':
-                        self.test_html(i)
+                    elif value:
+                        if value[0] == '<' and value[-1] == '>':
+                            self.test_html(i)
                         nl.append(i)
                 elif type(i) == dict:
                     # {"en:"Something",fr":"Quelque Chose"}
@@ -609,6 +611,8 @@ class BaseMetadataObject(object):
                 else:
                     nl.append(i)
             value = nl
+
+        # XXX: Value should now be added to current?
         object.__setattr__(self, which, value)
 
     def set_label(self, value):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,8 +1,10 @@
 """Test code for iiif_prezi.factory"""
+
 from __future__ import unicode_literals
 import unittest
 
 from iiif_prezi.factory import ManifestFactory, ConfigurationError
+
 
 class TestAll(unittest.TestCase):
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -4,7 +4,6 @@ import unittest
 
 from iiif_prezi.factory import ManifestFactory, ConfigurationError
 
-
 class TestAll(unittest.TestCase):
 
     def test01_init(self):
@@ -38,13 +37,12 @@ class TestAll(unittest.TestCase):
         self.assertEqual(img.height, 432)
 
     def test11_set_multiple_descriptions(self):
-        mf = ManifestFactory(mdbase="aa", imgbase="bb")
-        m = mf.manifest('a manifest')
-        m.description = ["a", "b"]
-        self.assertEqual(m.description, ["a", "b"])
         # XXX Decide if the following should also work
         # m.description = []
         # m.description = "a"
         # m.description = "b"
         # self.assertEqual(m.description, ["a", "b"])
-
+        mf = ManifestFactory(mdbase="aa", imgbase="bb")
+        m = mf.manifest('a manifest')
+        m.description = ["a", "b"]
+        self.assertEqual(m.description, ["a", "b"])

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -36,3 +36,15 @@ class TestAll(unittest.TestCase):
             'testimages/nci-vol-2303-72.jpg'), None)
         self.assertEqual(img.width, 648)
         self.assertEqual(img.height, 432)
+
+    def test11_set_multiple_descriptions(self):
+        mf = ManifestFactory(mdbase="aa", imgbase="bb")
+        m = mf.manifest('a manifest')
+        m.description = ["a", "b"]
+        self.assertEqual(m.description, ["a", "b"])
+        # XXX Decide if the following should also work
+        # m.description = []
+        # m.description = "a"
+        # m.description = "b"
+        # self.assertEqual(m.description, ["a", "b"])
+


### PR DESCRIPTION
Makes setting as a list work as it should, does not yet allow multiple calls to build it. Need to decide if that's a feature we want to make consistent, as it does work in other situations. 

Towards #33.