### PR TITLE
Remove cruft

### DIFF
--- a/tests/test_loader_fixures.py
+++ b/tests/test_loader_fixures.py
@@ -10,10 +10,6 @@ import difflib
 import json
 
 
-class TestError(PresentationError):
-    pass
-
-
 def print_warnings(reader):
     warns = reader.get_warnings()
     if warns:


### PR DESCRIPTION
Not sure why the `TestError` class was defined, doesn't seem used, `py.test` throws a warning about it. Removed.