### PR TITLE
Canvas id in err msg closes #52

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 dist
 htmlcov
 iiif_prezi.egg-info
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 # commands to install dependencies
 install:
   - pip install coveralls pep8 pep257 testfixtures

--- a/iiif_prezi/factory.py
+++ b/iiif_prezi/factory.py
@@ -672,12 +672,14 @@ class BaseMetadataObject(object):
             del d['context']
         for e in self._required:
             if e not in d:
+                # if the current object has an id, include it in the error message
+                id_msg = " with id '%s'" % self.id if self.id else ""
+                err_msg = "Resource type '%s'%s requires '%s' to be set" % (self._type, id_msg, e)
+
                 if e in self._structure_properties:
-                    raise StructuralError(
-                        "Resource type '%s' requires '%s' to be set" % (self._type, e), self)
+                    raise StructuralError(err_msg, self)
                 else:
-                    raise RequirementError(
-                        "Resource type '%s' requires '%s' to be set" % (self._type, e), self)
+                    raise RequirementError(err_msg, self)
         debug = self._factory.debug_level
         if debug.find("warn") > -1:
             for e in self._warn:

--- a/tests/test_loader_fixures.py
+++ b/tests/test_loader_fixures.py
@@ -156,6 +156,8 @@ class TestAll(unittest.TestCase):
         # self.assertRaises( DataError, error, 49 ) #FIXME/zimeon py2-py3 diff
         self.assertRaises(PresentationError, error, 50)  # was DataError
         self.assertRaises(RequirementError, error, 51)
+        self.assertRaises(RequirementError, error, 52)
+        # even though the label key exists, it must have a truthy value
 
     def test05_multipleContexts(self):
         fh = open('tests/multiple_contexts_fixture.json')
@@ -188,3 +190,7 @@ class TestAll(unittest.TestCase):
         js = json.loads(data)
         mr = ManifestReader(js)
         doc = mr.read()
+
+    def test52_canvas_id_in_error_message(self):
+        err_msg = "^Resource type 'sc:Canvas' with id '.*' requires 'label' to be set$"
+        self.assertRaisesRegexp(RequirementError, err_msg, error, 52)

--- a/tests/test_loader_fixures.py
+++ b/tests/test_loader_fixures.py
@@ -157,7 +157,6 @@ class TestAll(unittest.TestCase):
         self.assertRaises(PresentationError, error, 50)  # was DataError
         self.assertRaises(RequirementError, error, 51)
         self.assertRaises(RequirementError, error, 52)
-        # even though the label key exists, it must have a truthy value
 
     def test05_multipleContexts(self):
         fh = open('tests/multiple_contexts_fixture.json')
@@ -192,5 +191,8 @@ class TestAll(unittest.TestCase):
         doc = mr.read()
 
     def test52_canvas_id_in_error_message(self):
-        err_msg = "^Resource type 'sc:Canvas' with id '.*' requires 'label' to be set$"
+        # even though the label key exists in manifest 51, it must have a truthy value
+        # in this case it has a value of empty string ''
+        err_id = "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/2/c2.json"
+        err_msg = "^Resource type 'sc:Canvas' with id '%s' requires 'label' to be set$" % err_id
         self.assertRaisesRegexp(RequirementError, err_msg, error, 52)

--- a/tests/testdata/2.0/example/errors/52/manifest.json
+++ b/tests/testdata/2.0/example/errors/52/manifest.json
@@ -1,0 +1,34 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json", 
+  "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/1/manifest.json", 
+  "@type": "sc:Manifest", 
+  "label": "Test 1 Manifest: Minimum Required Fields", 
+  "within": "http://iiif.io/api/presentation/2.0/example/fixtures/collection.json", 
+  "sequences": [
+    {
+      "@type": "sc:Sequence", 
+      "canvases": [
+        {
+          "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/1/c1.json", 
+          "@type": "sc:Canvas", 
+          "label": "", 
+          "height": 1800, 
+          "width": 1200, 
+          "images": [
+            {
+              "@type": "oa:Annotation", 
+              "motivation": "sc:painting", 
+              "resource": {
+                "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/resources/page1-full.png", 
+                "@type": "dctypes:Image", 
+                "height": 1800, 
+                "width": 1200
+              }, 
+              "on": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/1/c1.json"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/testdata/2.0/example/errors/52/manifest.json
+++ b/tests/testdata/2.0/example/errors/52/manifest.json
@@ -11,7 +11,7 @@
         {
           "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/1/c1.json", 
           "@type": "sc:Canvas", 
-          "label": "", 
+          "label": "good label", 
           "height": 1800, 
           "width": 1200, 
           "images": [
@@ -25,6 +25,26 @@
                 "width": 1200
               }, 
               "on": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/1/c1.json"
+            }
+          ]
+        },
+        {
+          "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/2/c2.json", 
+          "@type": "sc:Canvas", 
+          "label": "", 
+          "height": 1800, 
+          "width": 1200, 
+          "images": [
+            {
+              "@type": "oa:Annotation", 
+              "motivation": "sc:painting", 
+              "resource": {
+                "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/resources/page2-full.png", 
+                "@type": "dctypes:Image", 
+                "height": 1800, 
+                "width": 1200
+              }, 
+              "on": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/2/c2.json"
             }
           ]
         }


### PR DESCRIPTION
re https://github.com/iiif-prezi/iiif-prezi/issues/52 and https://github.com/IIIF/presentation-validator/issues/66

Include the object id in StructuralError and RequirementError messages.
Had to tweak the travis build to get everything passing. 
